### PR TITLE
Correct Job affinity image on Jobs Flow and Status

### DIFF
--- a/articles/20_jobs_and_batch_services/02_jobs_flow_and_status.md
+++ b/articles/20_jobs_and_batch_services/02_jobs_flow_and_status.md
@@ -146,7 +146,7 @@ When ANY is set to a value greater than zero, the number shows the maximum numbe
 
 
 
-<img src="/articles/20_jobs_and_batch_services/images/02_jobs_and_batch_services_Nodes_Allocation2.png">
+<img src="/articles/20_jobs_and_batch_services/images/02_jobs_and_batch_services_Nodes_Allocation2.PNG.jpg">
 
 ### **Jobs Optimistic Locking Configuration**
 A configurable parameter **OPTIMISTIC_LOCKING** in the node's config.ini file can be set to support lightweight transactions between nodes to decide on a Job's allocation.


### PR DESCRIPTION
It looks like there are two of the same image in the images directory. The current one lists the affinity as Node 2, but based on the text description and rest of the image it seems like the affinity should say Node 1