### PR TITLE
Update Neo4j 5.26.24 download links (Linux)

### DIFF
--- a/articles/39_fabric_catalog/99_neo4j_linux_installation_guide.md
+++ b/articles/39_fabric_catalog/99_neo4j_linux_installation_guide.md
@@ -26,7 +26,7 @@ sudo su - neo4j
 
 #### Download K2view's Neo4j package:
 
-Download the link from [here](https://download.k2view.com/index.php/s/UHZ8NBSHunxRSiv/download).
+Download the link from [here](https://artifacts.share.cloud.k2view.com/k2view-neo4j/unix/k2view-neo4j-enterprise-5.26.24-unix.tar.gz).
 
 Note that this link is internal. If you don't have permissions to the folder, open a freshdesk ticket.
 


### PR DESCRIPTION
## Summary
Updates Neo4j 5.26.24 download links and version references in installation guides.

## Changes
- Updated download URLs to Neo4j 5.26.24
- Updated version references in installation commands
- Platform(s) updated: **Linux**

## Files Modified
- `articles/39_fabric_catalog/99_neo4j_linux_installation_guide.md`

## Testing
- [ ] Verify download links work
- [ ] Verify installation commands are correct

---
🤖 Auto-generated by [neo4j-package workflow](https://github.com/K2view-LTD/dev-infra/actions/runs/24346085461)