### PR TITLE
Update Neo4j 5.26.20 download links (Linux and Windows)

### DIFF
--- a/articles/39_fabric_catalog/99_neo4j_linux_installation_guide.md
+++ b/articles/39_fabric_catalog/99_neo4j_linux_installation_guide.md
@@ -26,18 +26,18 @@ sudo su - neo4j
 
 #### Download K2view's Neo4j package:
 
-Download the link from [here](https://download.k2view.com/index.php/s/UHZ8NBSHunxRSiv/download).
+Download the link from [here](https://artifacts.share.cloud.k2view.com/k2view-neo4j/unix/k2view-neo4j-enterprise-5.26.20-unix.tar.gz).
 
 Note that this link is internal. If you don't have permissions to the folder, open a freshdesk ticket.
 
 #### Untar the package:
 ```bash
-tar -zxvf k2view-neo4j-enterprise-5.26.24-unix.tar.gz
+tar -zxvf k2view-neo4j-enterprise-5.26.20-unix.tar.gz
 ```
 
 #### Remove tar.gz file:
 ```bash
-rm -rf k2view-neo4j-enterprise-5.26.24-unix.tar.gz
+rm -rf k2view-neo4j-enterprise-5.26.20-unix.tar.gz
 ```
 
 #### Source bash profile:

--- a/articles/39_fabric_catalog/99_neo4j_windows_installation_guide.md
+++ b/articles/39_fabric_catalog/99_neo4j_windows_installation_guide.md
@@ -28,16 +28,16 @@ cd '\path\to\neo4j-folder'
 
 #### Download K2view's Neo4j package:
 
-Download the link from [here](https://download.k2view.com/index.php/s/DtPLaMUoJjzNPlv/download).
+Download the link from [here](https://artifacts.share.cloud.k2view.com/k2view-neo4j/windows/k2view-neo4j-enterprise-5.26.20-windows.zip).
 
 #### Unzip the package:
 ```powershell
-Expand-Archive -Path .\k2view-neo4j-enterprise-5.26.24-windows.zip .
+Expand-Archive -Path .\k2view-neo4j-enterprise-5.26.20-windows.zip .
 ```
 
 #### Remove zip file:
 ```powershell
-Remove-Item -Path .\k2view-neo4j-enterprise-5.26.24-windows.zip
+Remove-Item -Path .\k2view-neo4j-enterprise-5.26.20-windows.zip
 ```
 
 #### Environment Variables in Windows:


### PR DESCRIPTION
## Summary
Updates Neo4j 5.26.20 download links and version references in installation guides.

## Changes
- Updated download URLs to Neo4j 5.26.20
- Updated version references in installation commands
- Platform(s) updated: **Linux and Windows**

## Files Modified
- `articles/39_fabric_catalog/99_neo4j_linux_installation_guide.md`
- `articles/39_fabric_catalog/99_neo4j_windows_installation_guide.md`

## Testing
- [ ] Verify download links work
- [ ] Verify installation commands are correct

---
🤖 Auto-generated by [neo4j-update-versions workflow](https://github.com/K2view-LTD/dev-infra/actions/runs/24628363376)