### PR TITLE
Kiril/8.4 ldap update

### DIFF
--- a/articles/15_web_services_and_graphit/05_custom_ws.md
+++ b/articles/15_web_services_and_graphit/05_custom_ws.md
@@ -42,7 +42,7 @@ Where:
 
   To see the profiling information:
 
-  * Open the [Fabric Logs](/articles/21_Fabric_troubleshooting/02_Fabric_troubleshooting_log_files.md#log-files) of the Fabric session that processed the Web Service in the $K2_HOME/logs/k2fabric.log. At the Studio, the Log files are accessible from the log viewer.
+  * Open the [Fabric Logs](/articles/21_Fabric_troubleshooting/02_Fabric_troubleshooting_log_files.md#log-files) of the Fabric session that processed the Web Service in the $FABRIC_HOME/logs/k2fabric.log. At the Studio, the Log files are accessible from the log viewer.
   * Search for the lines containing 'Starting webservice':
 
 

--- a/articles/16_deploy_fabric/03_offline_deploy.md
+++ b/articles/16_deploy_fabric/03_offline_deploy.md
@@ -68,7 +68,7 @@ To build the artifacts and the deployment together, in one step, from the server
 </studio>
 
 ### Build and Deploy Scripts Syntax and Options
-The following table describes the syntax and the mandatory/optional parameters for calling the deployment scripts. The scripts are located under **$K2_HOME/fabric/scripts** in the Fabric server.
+The following table describes the syntax and the mandatory/optional parameters for calling the deployment scripts. The scripts are located under **$FABRIC_HOME/fabric/scripts** in the Fabric server.
 
 
 

--- a/articles/17_fabric_credentials/01_fabric_credentials_overview.md
+++ b/articles/17_fabric_credentials/01_fabric_credentials_overview.md
@@ -195,8 +195,8 @@ Define credentials by either Admin UI (Security tab) or Fabric commands, as foll
 
 ### Bootstrap Credentials
 Fabric can also be started with predefined API keys, roles, and permissions. This is available since Fabric 7.2.1.
-- Turn on this capability by adding a new line containing "rolespermissions" to the *modules* file, located at [$K2_HOME/config](/articles/02_fabric_architecture/02_fabric_directories.md#k2_homeconfig) directory.
-- Create a file named **rolesPrivileges.json** at [$K2_HOME/config](/articles/02_fabric_architecture/02_fabric_directories.md#k2_homeconfig) directory.
+- Turn on this capability by adding a new line containing "rolespermissions" to the *modules* file, located at [$FABRIC_HOME/config](/articles/02_fabric_architecture/02_fabric_directories.md#k2_homeconfig) directory.
+- Create a file named **rolesPrivileges.json** at [$FABRIC_HOME/config](/articles/02_fabric_architecture/02_fabric_directories.md#k2_homeconfig) directory.
 - Edit the file with the required values. It is built from two main independent objects: "roles" and "apikeys", where each can be set or skipped independently of the other.
    - Define roles' associated operations, per role, at the "roles" array object.
    - Define API keys association to roles, per API key, at the `"apikeys"` array object.

--- a/articles/17_fabric_credentials/03_fabric_credentials_backup.md
+++ b/articles/17_fabric_credentials/03_fabric_credentials_backup.md
@@ -7,11 +7,11 @@ To prevent data loss and speed up the setup process, it is recommended to create
 ### Example of Exporting Data
 
 ~~~bash
-echo "COPY k2auth.roles TO '$K2_HOME/k2auth.roles.csv' WITH HEADER = TRUE ;"|cqlsh -u[user] -p[password]
-echo "COPY k2auth.credentials TO '$K2_HOME/k2auth.credentials.csv' WITH HEADER = TRUE ;"|cqlsh -u[user] -p[password]
-echo "COPY k2auth.permissions TO '$K2_HOME/k2auth.permissions.csv' WITH HEADER = TRUE ;"|cqlsh -u[user] -p[password]
-echo "COPY k2auth.user_credentials TO '$K2_HOME/k2auth.user_credentials.csv' WITH HEADER = TRUE ;"|cqlsh -u[user] -p[password]
-echo "COPY system_auth.roles TO '$K2_HOME/system_auth.roles.csv' WITH HEADER = TRUE ;"|cqlsh -u[user] -p[password] 
+echo "COPY k2auth.roles TO '$FABRIC_HOME/k2auth.roles.csv' WITH HEADER = TRUE ;"|cqlsh -u[user] -p[password]
+echo "COPY k2auth.credentials TO '$FABRIC_HOME/k2auth.credentials.csv' WITH HEADER = TRUE ;"|cqlsh -u[user] -p[password]
+echo "COPY k2auth.permissions TO '$FABRIC_HOME/k2auth.permissions.csv' WITH HEADER = TRUE ;"|cqlsh -u[user] -p[password]
+echo "COPY k2auth.user_credentials TO '$FABRIC_HOME/k2auth.user_credentials.csv' WITH HEADER = TRUE ;"|cqlsh -u[user] -p[password]
+echo "COPY system_auth.roles TO '$FABRIC_HOME/system_auth.roles.csv' WITH HEADER = TRUE ;"|cqlsh -u[user] -p[password] 
 ~~~
 
 
@@ -19,11 +19,11 @@ echo "COPY system_auth.roles TO '$K2_HOME/system_auth.roles.csv' WITH HEADER = T
 ### Example of Importing Data
 
 ~~~bash
-echo "COPY k2auth.roles FROM '$K2_HOME/k2auth.roles.csv' WITH HEADER = TRUE ;"|cqlsh -u[user] -p[password]
-echo "COPY k2auth.credentials FROM '$K2_HOME/k2auth.credentials.csv' WITH HEADER = TRUE ;"|cqlsh -u[user] -p[password]
-echo "COPY k2auth.permissions FROM '$K2_HOME/k2auth.permissions.csv' WITH HEADER = TRUE ;"|cqlsh -u[user] -p[password]
-echo "COPY k2auth.user_credentials FROM '$K2_HOME/k2auth.user_credentials.csv' WITH HEADER = TRUE ;"|cqlsh -u[user] -p[password]
-echo "COPY system_auth.roles FROM '$K2_HOME/system_auth.roles.csv' WITH HEADER = TRUE ;"|cqlsh -u[user] -p[password]
+echo "COPY k2auth.roles FROM '$FABRIC_HOME/k2auth.roles.csv' WITH HEADER = TRUE ;"|cqlsh -u[user] -p[password]
+echo "COPY k2auth.credentials FROM '$FABRIC_HOME/k2auth.credentials.csv' WITH HEADER = TRUE ;"|cqlsh -u[user] -p[password]
+echo "COPY k2auth.permissions FROM '$FABRIC_HOME/k2auth.permissions.csv' WITH HEADER = TRUE ;"|cqlsh -u[user] -p[password]
+echo "COPY k2auth.user_credentials FROM '$FABRIC_HOME/k2auth.user_credentials.csv' WITH HEADER = TRUE ;"|cqlsh -u[user] -p[password]
+echo "COPY system_auth.roles FROM '$FABRIC_HOME/system_auth.roles.csv' WITH HEADER = TRUE ;"|cqlsh -u[user] -p[password]
 ~~~
 
 

--- a/articles/18_fabric_cdc/03_cdc_messages.md
+++ b/articles/18_fabric_cdc/03_cdc_messages.md
@@ -89,7 +89,7 @@ Fabric has the following CDC messages:
 
 
 
-Note that you can find samples of CDC messages under $K2_HOME/fabric/samples/cdc-messages directory of Fabric server.
+Note that you can find samples of CDC messages under $FABRIC_HOME/fabric/samples/cdc-messages directory of Fabric server.
 
 ## Serialization
 CDC messages are stored in Kafka topics by their CDC Consumer Name as defined in the Fabric Studio and can be serialized or deserialized using the **com.k2view.fabric.cdc.Serialization** Fabric Java Class.

--- a/articles/18_fabric_cdc/cdc_consumers/search/04_search_templates.md
+++ b/articles/18_fabric_cdc/cdc_consumers/search/04_search_templates.md
@@ -2,7 +2,7 @@
 
 Fabric enables adding templates for Search fields when the default settings do not match a search's needs. For example, to search by fields that contain special characters like an email address. 
 -  Each template is in JSON format and creates index settings in the Search provider.
--  All templates must be saved in the Fabric server under the **$K2_HOME/config/cdc-tags** directory.
+-  All templates must be saved in the Fabric server under the **$FABRIC_HOME/config/cdc-tags** directory.
 -  Fabric has  **default templates** that are saved under the **cdc-tags** directory:
 
 <table width="900pxl">

--- a/articles/21_Fabric_troubleshooting/02_Fabric_troubleshooting_log_files.md
+++ b/articles/21_Fabric_troubleshooting/02_Fabric_troubleshooting_log_files.md
@@ -23,18 +23,6 @@ The latest log is always named **k2fabric.log**, and is [rolled to a new file](/
 
 The ***.err** and ***.** **out** log files are created during [Fabric restart]( /articles/02_fabric_architecture/03_fabric_basics_getting_started.md#k2fabric-restart) and are not rolled to a new file. Always Check these files when an error occurs. 
 
-#### **IID Finder Log Files**
-
-The IID Finder has a separate log and configuration files:
-
-~~~
-    $FABRIC_HOME/config/logback-iid_finder.xml
-    $FABRIC_HOME/config/logback-init_finder.xml
-    $FABRIC_HOME/logs/iidfinder.log
-~~~
-**logback-iid_finder.xml** is a configuration file for IID Finder log files, while **logback-init_finder.xml** is responsible for the creation of IID Finder tables in Cassandra.
-<!--Click for more information about the IID Finder. -- Drop 3 -> add a link to IID Finder -->
-
 ### **Log Files Location & Rolling Policy**
 
 While log files convey useful information, they grow bigger over time, and eventually their size can become an issue. This problem is addressed in the **logback.xml** configuration file. To prevent unwanted downtime, **rolling file appenders** automatically archive the current log file and resume logging in a new file when specific predefined conditions occur. Log files can be rolled based on size, date/time and a combination of size and date/time. In addition, you can configure to automatically compress and later delete old log files.

--- a/articles/21_Fabric_troubleshooting/02_Fabric_troubleshooting_log_files.md
+++ b/articles/21_Fabric_troubleshooting/02_Fabric_troubleshooting_log_files.md
@@ -7,7 +7,7 @@ All activities performed in Fabric are written into log files in the server and 
 Logs are configured in the **logback.xml** file which is located on the Fabric server in:
 
 ~~~
-    $K2_HOME/config/logback.xml
+    $FABRIC_HOME/config/logback.xml
 ~~~
 
 Settings like the [log files location and rolling policy](/articles/21_Fabric_troubleshooting/02_Fabric_troubleshooting_log_files.md#log-files-location--rolling-policy) and the [log level](/articles/21_Fabric_troubleshooting/02_Fabric_troubleshooting_log_files.md#log-level) can be updated in the **logback.xml** file.  
@@ -16,7 +16,7 @@ For additional information, refer to http://logback.qos.ch/manual/configuration.
 
 ### Log Files 
 
-Fabric log files are located in [$K2_HOME/logs](/articles/02_fabric_architecture/02_fabric_directories.md#k2_homelogs) directory.
+Fabric log files are located in [$FABRIC_HOME/logs](/articles/02_fabric_architecture/02_fabric_directories.md#fabric_homelogs) directory.
 The location of a log file can be configured in the [logback.xml](/articles/21_Fabric_troubleshooting/02_Fabric_troubleshooting_log_files.md#log-files-location--rolling-policy) log configuration file. 
 
 The latest log is always named **k2fabric.log**, and is [rolled to a new file](/articles/21_Fabric_troubleshooting/02_Fabric_troubleshooting_log_files.md#log-files-location--rolling-policy) as soon as it reaches a specific size. 
@@ -28,9 +28,9 @@ The ***.err** and ***.** **out** log files are created during [Fabric restart]( 
 The IID Finder has a separate log and configuration files:
 
 ~~~
-    $K2_HOME/config/logback-iid_finder.xml
-    $K2_HOME/config/logback-init_finder.xml
-    $K2_HOME/logs/iidfinder.log
+    $FABRIC_HOME/config/logback-iid_finder.xml
+    $FABRIC_HOME/config/logback-init_finder.xml
+    $FABRIC_HOME/logs/iidfinder.log
 ~~~
 **logback-iid_finder.xml** is a configuration file for IID Finder log files, while **logback-init_finder.xml** is responsible for the creation of IID Finder tables in Cassandra.
 <!--Click for more information about the IID Finder. -- Drop 3 -> add a link to IID Finder -->
@@ -53,7 +53,7 @@ While log files convey useful information, they grow bigger over time, and event
     </appender>
 ~~~
 
-The above configuration defines the **k2fabric.log** log file located in the Fabric server under the **$K2_HOME/logs** directory. The rolling policy of the above appender is based on a combination of size and date/time. A new file is created every day. The maximum size of a log file is 20 MB and the total size of the files is 3 GB. History is saved for 10 days. 
+The above configuration defines the **k2fabric.log** log file located in the Fabric server under the **$FABRIC_HOME/logs** directory. The rolling policy of the above appender is based on a combination of size and date/time. A new file is created every day. The maximum size of a log file is 20 MB and the total size of the files is 3 GB. History is saved for 10 days. 
 
 Note that to define the maxHistory in hours rather than in days, edit the fileNamePattern tag to include the following pattern: {yyyy-MM-dd-hh}.
 
@@ -71,7 +71,7 @@ When required, a new log file can be created by configuring a new **appender** i
     </appender>
 ~~~
 
-The above configuration defines the **monitoring.log** file located in the Fabric server under the **$K2_HOME/logs** directory. The rolling policy of the above appender is based on date/time. A new file is created every day. History is saved for 7 days. 
+The above configuration defines the **monitoring.log** file located in the Fabric server under the **$FABRIC_HOME/logs** directory. The rolling policy of the above appender is based on date/time. A new file is created every day. History is saved for 7 days. 
 
 ### **Log Level**
 The log level parameter defines which messages are written into the log file. There are four log levels (from the least severe to the most severe): DEBUG, INFO, WARN and ERROR. 

--- a/articles/26_fabric_security/18_FIPS_implementation.md
+++ b/articles/26_fabric_security/18_FIPS_implementation.md
@@ -22,7 +22,7 @@ The Fabric command ```version fips``` returns the FIPS version currently used an
 #### FIPS with mode set to **ON**
 
 To switch on FIPS mode, carry out the following steps:
-- Go to the **$K2_HOME/config/** directory,
+- Go to the **$FABRIC_HOME/config/** directory,
 - Open the **modules.ini** file
 - Modify the fips entry to reflect the following value: ```fips:mode=on```
 

--- a/articles/26_fabric_security_iam/11.1_user_IAM_AD_LDAP.md
+++ b/articles/26_fabric_security_iam/11.1_user_IAM_AD_LDAP.md
@@ -18,7 +18,7 @@ Do the following:
  Below is an example of such parameters: 
 
    - **user:** k2vfabric
-   - **user password:** Q1w2e3r4t5
+   - **user password:** changeit
    - **user group:** K2vtdaadmin
    - **admin_dn:** `CN=K2vtdaadmin,cn=users,DC=k2vfabric` 
    - **users_base_dn:** `CN=Users,DC=k2vfabric,DC=local`
@@ -42,19 +42,28 @@ The following steps must be carried out on all Fabric nodes by the root user:
     In this file, we will insert the name of the **group** that the user will use as the **fabric admin**, and the AD to which the user belongs. In our example **K2vtdaadmin**
 
    ~~~bash
-   cd $K2_HOME/
-   echo "K2vtdaadmin" > $K2_HOME/config/admin_privileges
+   echo "K2vtdaadmin" > $FABRIC_HOME/config/admin_privileges
    ~~~
 
-- Config Fabric's config.ini file as follows: 
+  > **NOTE:** `admin_privileges` is applied only on the **very first Fabric startup**. After that, role management must be done within Fabric directly (via the Management Center or Fabric commands). Modifying this file after first start has no effect.
+
+- Config Fabric's config.ini file with the following parameters:
+
+   ~~~ini
+   [fabric]
+   SERVER_AUTHENTICATOR=adldap
+
+   [adldap_auth]
+   url=ldap://k2-fabric-ldap.k2vfabric.local:389
+   admin_dn=CN=K2vtdaadmin,cn=users,DC=k2vfabric,DC=local
+   admin_password=<admin-password>
+   users_base_dn=CN=Users,DC=k2vfabric,DC=local
+   ~~~
+
+   You can set each parameter using `merge-config.sh` — an idempotent script that is safe to re-run. Use `-s` for the section, `-k` for the key, and `-v` for the value. For example:
 
    ~~~bash
-   cd $K2_HOME/
-   sed -i "s@#SERVER_AUTHENTICATOR=.*@SERVER_AUTHENTICATOR=adldap@" $K2_HOME/config/config.ini
-   sed -i "s@#url=.*@url=ldaps://k2-fabric-ldap.k2vfabric.local:636@" $K2_HOME/config/config.ini
-   sed -i "s@#admin_dn=.*@admin_dn=CN=K2vtdaadmin,cn=users,DC=k2vfabric,DC=local@" $K2_HOME/config/config.ini
-   sed -i "s@#admin_password=.*@admin_password=Q1w2e3r4t5@" $K2_HOME/config/config.ini
-   sed -i "s@#users_base_dn=.*@users_base_dn=CN=Users,DC=k2vfabric,DC=local@" $K2_HOME/config/config.ini 
+   $FABRIC_HOME/fabric/scripts/merge-config.sh -s fabric -k SERVER_AUTHENTICATOR -v adldap -f $FABRIC_HOME/config/config.ini
    ~~~
 
 

--- a/articles/26_fabric_security_iam/11.2_user_IAM_AD_LDAPS.md
+++ b/articles/26_fabric_security_iam/11.2_user_IAM_AD_LDAPS.md
@@ -18,7 +18,7 @@ Carry out the following steps:
  Below is an example of such parameters: 
 
    - **user:** k2vfabric
-   - **user password:** Q1w2e3r4t5
+   - **user password:** changeit
    - **user group:** K2vtdaadmin
    - **admin_dn:** `CN=K2vtdaadmin,cn=users,DC=k2vfabric`
    - **users_base_dn:** `CN=Users,DC=k2vfabric,DC=local`
@@ -29,12 +29,6 @@ Carry out the following steps:
 
 The following steps must be carried out on all Fabric nodes by the root user:
 
-- Update the /etc/hosts (if you cannot resolve the AD's DNS)
-
-  ~~~bash
-  echo "10.21.1.134 k2-fabric-ldap.k2vfabric.local" >> /etc/hosts
-  ~~~
-
 - Connect as **fabric** user 
 
 - Update the admin_privileges file **on one fabric node only** (the one that you will start with first).
@@ -42,51 +36,43 @@ The following steps must be carried out on all Fabric nodes by the root user:
     In this file, we will insert the name of the **group** that the user will use as the **fabric admin**, and the AD to which the user belongs. In our example **K2vtdaadmin**
 
    ~~~bash
-   cd $K2_HOME/
-   echo "K2vtdaadmin" > $K2_HOME/config/admin_privileges
+   echo "K2vtdaadmin" > $FABRIC_HOME/config/admin_privileges
    ~~~
 
-- Config Fabric's config.ini file as follows: 
+  > **NOTE:** `admin_privileges` is applied only on the **very first Fabric startup**. After that, role management must be done within Fabric directly (via the Management Center or Fabric commands). Modifying this file after first start has no effect.
 
+- Config Fabric's config.ini file with the following parameters:
+
+   ~~~ini
+   [fabric]
+   SERVER_AUTHENTICATOR=adldap
+
+   [adldap_auth]
+   url=ldaps://k2-fabric-ldap.k2vfabric.local:636
+   admin_dn=CN=K2vtdaadmin,cn=users,DC=k2vfabric,DC=local
+   admin_password=<admin-password>
+   users_base_dn=CN=Users,DC=k2vfabric,DC=local
+   ~~~
+
+   You can set each parameter using `merge-config.sh` — an idempotent script that is safe to re-run. Use `-s` for the section, `-k` for the key, and `-v` for the value. For example:
    ~~~bash
-   cd $K2_HOME/
-   sed -i "s@#SERVER_AUTHENTICATOR=.*@SERVER_AUTHENTICATOR=adldap@" $K2_HOME/config/config.ini
-   sed -i "s@#url=.*@url=ldaps://k2-fabric-ldap.k2vfabric.local:636@" $K2_HOME/config/config.ini
-   sed -i "s@#admin_dn=.*@admin_dn=CN=K2vtdaadmin,cn=users,DC=k2vfabric,DC=local@" $K2_HOME/config/config.ini
-   sed -i "s@#admin_password=.*@admin_password=Q1w2e3r4t5@" $K2_HOME/config/config.ini
-   sed -i "s@#users_base_dn=.*@users_base_dn=CN=Users,DC=k2vfabric,DC=local@" $K2_HOME/config/config.ini 
+   $FABRIC_HOME/fabric/scripts/merge-config.sh -s fabric -k SERVER_AUTHENTICATOR -v adldap -f $FABRIC_HOME/config/config.ini
    ~~~
- 
+
 The following steps are unique to LDAPS (as opposed to LDAP):
    
-- Import an LDAPS certificate to the Java truststore 
-- If Fabric is *not hardened* run the following:
+- Import an LDAPS certificate to the Java truststore using `certificates.sh addtrust`:
 
 ~~~bash
-keytool -importcert -file root_cer.cer -keystore apps/java/jre/lib/security/cacerts -alias "ldap"
+$FABRIC_HOME/fabric/scripts/certificates.sh addtrust ldap <path-to-ca-cert.cer>
 ~~~
 
-- You will be prompted to enter a password. Use **changeit** 
-- When you are prompted for a confirmation, input **yes**
-
-
-
-See this example: 
-
-
-
-<img src="/articles/images/cer_import.png">
-
-- If Fabric *is* hardened, run the following: 
+  By default, this imports into `$JAVA_HOME/lib/security/cacerts`. To use a different truststore, set `FABRIC_TRUSTSTORE_PATH` before running:
 
 ~~~bash
-keytool -importcert -file root_cer.cer -keystore .cassandra_ssl/cassandra.truststore -alias "ldap"
+export FABRIC_TRUSTSTORE_PATH=<path-to-truststore>
+$FABRIC_HOME/fabric/scripts/certificates.sh addtrust ldap <path-to-ca-cert.cer>
 ~~~
-
-- You will be prompted to enter a password. Use **Q1w2e3r4t5** 
-- When you are prompted for a confirmation, input **yes**
-
-
 
 For more information about how Fabric works with LDAP, see [here](/articles/26_fabric_security_iam/11_user_IAM_LDAP.md). For more information about SAML configuration in Fabric, please read [here](/articles/26_fabric_security_iam/13_user_IAM_configuration.md#saml-configuration).
 

--- a/articles/26_fabric_security_iam/11.2_user_IAM_AD_LDAPS.md
+++ b/articles/26_fabric_security_iam/11.2_user_IAM_AD_LDAPS.md
@@ -67,7 +67,7 @@ The following steps are unique to LDAPS (as opposed to LDAP):
 $FABRIC_HOME/fabric/scripts/certificates.sh addtrust ldap <path-to-ca-cert.cer>
 ~~~
 
-  By default, this imports into `$JAVA_HOME/lib/security/cacerts`. To use a different truststore, set `FABRIC_TRUSTSTORE_PATH` before running:
+  By default, this imports into `$FABRIC_HOME/config/.truststore`. To use a different truststore, set `FABRIC_TRUSTSTORE_PATH` before running:
 
 ~~~bash
 export FABRIC_TRUSTSTORE_PATH=<path-to-truststore>

--- a/articles/26_fabric_security_iam/13_user_IAM_configuration.md
+++ b/articles/26_fabric_security_iam/13_user_IAM_configuration.md
@@ -183,19 +183,10 @@ Obtain the following values from your IdP’s administration interface:
   The IdP’s public key certificate. Import it into the Fabric truststore with the following command:
 
   ```bash
-  keytool -importcert \
-    -alias <ALIAS-NAME> \
-    -file <full-path-to-downloaded-cert-file> \
-    -storetype JKS \
-    -keystore <full-path-to-truststore-file>
+  $FABRIC_HOME/fabric/scripts/certificates.sh addtrust <ALIAS-NAME> <full-path-to-downloaded-cert-file>
   ```
 
-The truststore path and related parameters are defined in the `jvm.options` file.  
-In the **TLS/SSL SETTINGS** section, check the property:
-
-   ```bash
-   $K2_HOME/.cassandra_ssl/cassandra.truststore
-   ```
+The default truststore path is `$FABRIC_HOME/config/.truststore`.
 The chosen alias name must also be set in the configuration for the IDP_CERT_ALIAS property.
 (You may use any alias name, as long as it matches here and in the configuration.)
 
@@ -214,7 +205,7 @@ The chosen alias name must also be set in the configuration for the IDP_CERT_ALI
       -keystore <full-path-to-keystore-file>
    ```
 
-   The keystore path and related parameters are set in the `jvm.options` file. In the TLS/SSL SETTINGS section, review the `javax.net.ssl.keyStore` property. These values are configured for a hardened environment. For example: `$K2_HOME/.cassandra_ssl/keystore.jks`.
+   The default keystore path is `$FABRIC_HOME/config/.keystore`.
 
   The specified alias name must be used for the *SP_CERT_ALIAS* property in your configuration. `fabric_cert` is used by default in the config.ini. Ensure that you use the alias of the already stored certificate. Please verify the alias using the keytool list command.
 
@@ -287,7 +278,7 @@ When Fabric is running on a Windows OS, typically during project implementation 
 
 ##### Admin Role Settings
 
-When LDAP is used as an authenticator, an admin role is automatically created for Fabric Bootstrap. The admin role's name should be configured in the *admin_privileges* configuration file (Use $K2_HOME/config.template/admin_privileges.template file as reference). 
+When LDAP is used as an authenticator, an admin role is automatically created for Fabric Bootstrap. The admin role's name should be configured in the *admin_privileges* configuration file (Use $FABRIC_HOME/config.template/admin_privileges.template file as reference). 
 
 The LDAP owner should provide the name of the role.
 

--- a/articles/26_fabric_security_iam/17_user_IAM_custom_authenticator.md
+++ b/articles/26_fabric_security_iam/17_user_IAM_custom_authenticator.md
@@ -23,7 +23,7 @@ It implements 3 methods:
 
 ### How to pack and deploy a custom authenticator
 
-Pack the authenticator into a JAR file and locate it under the $K2_HOME/ExternalJars directory.
+Pack the authenticator into a JAR file and locate it under the $FABRIC_HOME/ExternalJars directory.
 
 The JAR should be copied to each node in the cluster.
 

--- a/articles/26_fabric_security_mk/10_fabric_defined_master_key.md
+++ b/articles/26_fabric_security_mk/10_fabric_defined_master_key.md
@@ -17,34 +17,27 @@ Set the ``MASTERKEY_KEY_STORE_ENABLED`` parameter of the config.ini file to **fa
 ### Generate Master Key Using KeyStore
 Set the ``MASTERKEY_KEY_STORE_ENABLED`` parameter of the config.ini file to **true**.
 
-#### Create KeyStore Directory 
-After adding the encryption module to the fabric-server-start.sh module, create the Keystore folder under the k2view home directory for all nodes:
-```bash
-cd $K2_HOME
-mkdir .keystore
-```
-
 #### Run the keytool
 Run the ```keytool``` command on the coordinator node:
 
 ~~~bash
-keytool -genseckey -alias masterkey_key_name -keyalg aes -keysize 256 -storepass <password> -keystore  $K2_HOME/.keystore/fabric.keystore -storetype PKCS12
+
+keytool -genseckey -alias masterkey_key_name -keyalg aes -keysize 256 -storepass <password> -keystore  $FABRIC_HOME/config/.keystore -storetype PKCS12
 ~~~
 
 - Copy the key to all other nodes:
 
 ~~~bash
-scp $K2_HOME/.keystore/fabric.keystore fabric@10.10.10.10:/$K2_HOME/.keystore/
+scp $FABRIC_HOME/config/.keystore fabric@10.10.10.10:/$FABRIC_HOME/config/.keystore
 ~~~
 
 
-
-#### Edit Config.ini Script
+#### Edit Config.ini
 - Edit the **KEY_STORE_PASSWORD** parameter in the config.ini to the password used in the Keytool command, and enable the **KEY_STORE_LOCATION** parameter and set it to point to the correct path for all Fabric nodes:
 
 ```bash
-sed -i "s@#KEY_STORE_LOCATION=.*@KEY_STORE_LOCATION=$K2_HOME/.keystore/fabric.keystore@" $K2_HOME/config/config.ini
-sed -i 's@#KEY_STORE_PASSWORD=.*@KEY_STORE_PASSWORD= <password>@' $K2_HOME/config/config.ini
+$FABRIC_HOME/fabric/scripts/merge-config.sh -s encryption -k KEY_STORE_LOCATION -v $FABRIC_HOME/config/.keystore -f $FABRIC_HOME/config/config.ini
+$FABRIC_HOME/fabric/scripts/merge-config.sh -s encryption -k KEY_STORE_PASSWORD -v <password> -f $FABRIC_HOME/config/config.ini
 ```
 
 ### Restart Fabric Nodes

--- a/articles/98_installation_and_upgrade/Install_on_Linux/03_fabric_scale.md
+++ b/articles/98_installation_and_upgrade/Install_on_Linux/03_fabric_scale.md
@@ -53,7 +53,7 @@ Ensure all necessary certificates are imported into the keystore and truststore 
 
 ## Project Files
 
-As mentioned above, Fabric nodes obtain the project deployment from the system DB when they start up. Nevertheless, if you are using additional files in your project, such as JAR libraries, copy them to the node's Fabric home folder (e.g., $K2_HOME/ExternalJars).
+As mentioned above, Fabric nodes obtain the project deployment from the system DB when they start up. Nevertheless, if you are using additional files in your project, such as JAR libraries, copy them to the node's Fabric home folder (e.g., $FABRIC_HOME/ExternalJars).
 
 ## Start Fabric
 


### PR DESCRIPTION
This PR update some legacy concepts 

* Remove IID Finder Log Files section as this files not exist any more in fabric 8.4
* Replace K2_HOME with FABRIC_HOME
* Update default keystore and trustore path
* LDAP
  * Replace password Q1w2e3r4t5 with changeit
  * Replace 'sed' commands with general instructions and merge-config.sh
  * Replace direct keytool commands with certificates.sh