### PR TITLE
Kiril/8.4 cassandra

### DIFF
--- a/articles/98_installation_and_upgrade/Install_on_Linux/01_Fabric_8.xx_Installation_intro.md
+++ b/articles/98_installation_and_upgrade/Install_on_Linux/01_Fabric_8.xx_Installation_intro.md
@@ -32,34 +32,45 @@ On __all__ servers
 ~~~bash
 mkdir -p /opt/apps
 chmod 755 /opt/apps
+groupadd -f k2view
 ~~~
 
 On each server, depending on the service you wish to install, run the appropriate useradd command.
 (on a single host setup, run all commands on the same server)
 For Fabric Sever
 ~~~bash
-useradd -m -d /opt/apps/fabric  -s /bin/bash fabric
+useradd -m -d /opt/apps/fabric -g k2view -s /bin/bash fabric
 ~~~
 For Cassandra Instance (only in case Cassandrta is planned as system DB)
 ~~~bash
-useradd -m -d /opt/apps/cassandra  -s /bin/bash cassandra
+useradd -m -d /opt/apps/cassandra -g k2view -s /bin/bash cassandra
 ~~~
 In Some cases, Kafka instance or cluster will be required.
-
 ~~~bash
-useradd -m -d /opt/apps/kafka  -s /bin/bash kafka
+useradd -m -d /opt/apps/kafka -g k2view -s /bin/bash kafka
 ~~~
-
 
 
 Update the OS limits as follows:
-
+For the Fabric user:
 ~~~bash
+# Allow root an unlimited number of processes
 echo "root soft    nproc     unlimited" >> /etc/security/limits.conf
-echo "cassandra - nofile 1000000" >> /etc/security/limits.conf
-echo "cassandra - nproc 500000" >> /etc/security/limits.conf
+# Raise the open-files and process limits for the fabric user
 echo "fabric - nofile 1000000" >> /etc/security/limits.conf
 echo "fabric - nproc 500000" >> /etc/security/limits.conf
+~~~
+
+For the Cassandra user:
+~~~bash
+# Raise the open-files and process limits for the cassandra user
+echo "cassandra - nofile 1000000" >> /etc/security/limits.conf
+echo "cassandra - nproc 500000" >> /etc/security/limits.conf
+~~~
+
+For the Kafka user:
+~~~bash
+# Raise the open-files and process limits for the kafka user
 echo "kafka hard nofile 1000000" >> /etc/security/limits.conf
 echo "kafka soft nofile 1000000" >> /etc/security/limits.conf
 echo "kafka - nproc 500000" >> /etc/security/limits.conf

--- a/articles/98_installation_and_upgrade/Install_on_Linux/Cassandra_Setup.md
+++ b/articles/98_installation_and_upgrade/Install_on_Linux/Cassandra_Setup.md
@@ -1,111 +1,313 @@
 # Cassandra Setup
 
-The provided Cassandra package and setup scripts were designed for either a single-node or a multi-node environments.
+This guide describes how to install and configure **vanilla Apache Cassandra 4.1.x** as a Fabric System Database, for either single-node or multi-node environments.
 
-Follow the setup script for a proper configuration, depending on your environment.
+Apply the configuration on each node separately, in the order of the designated node numbers (start with seed node 1, then continue one by one). Do not configure or start the nodes simultaneously, as this might cause configurational and operational issues.
 
-The script should be run separately on each node, in the order of designated node numbers. It should not be run simultaneously as this might cause configurational and operational issues.
+**Official reference:** https://cassandra.apache.org/doc/4.1/
 
 ## Version Considerations
 
-Ensure the correct Python version is installed on Fabric nodes where Cassandra tools are invoked.
+This guide targets **Apache Cassandra 4.1.x**.
 
- - Cassandra 3.11.14 requires **Python 2.7** for utilities like `cqlsh`.  
- - Cassandra 4.0.3 and 4.1.3 require **Python 3.6 or higher**.  
-
-Users deploying Cassandra 4.x (4.0.3 or 4.1.3) need Python 3.6+ for running cqlsh and other tools.
+- **Java 8 or 11** must be on the `PATH` (verify with `java -version`). Cassandra 4.1.x does not support Java 17+.
+- **Python 3.6 or higher** is required for utilities such as `cqlsh` (verify with `python3 --version`).
 
 > *Note:* On systems such as RHEL 7 that default to Python 2.7, be sure to explicitly install and use a Python 3 interpreter (e.g., `python3`) when invoking Cassandra utilities.
 
-> **Version-Specific Behavior**  
-> The provided setup script is compatible with Cassandra 3.11.14, 4.0.3, and 4.1.3. However, ensure that the Python interpreter you use corresponds to the Cassandra version:
-> - Use `python` (pointing to Python 2.7) for Cassandra 3.11.14.  
-> - Use `python3` (Python 3.6+) for Cassandra 4.x.  
-> All other package setup steps (download, unpacking, script execution) remain identical across supported versions.
-
+> **Cassandra 4.x Configuration**  
+> After configuration, review your `cassandra.yaml` for any deprecated options and align the Java/TLS settings with Cassandra 4.1.x performance and security guidelines.
 
 ## Pre-Installation Steps
 
 1. Make sure all Cassandra-related activities were performed; click [here](01_Fabric_8.xx_Installation_intro.md) to get the full list of activities.
 
-2. Verify that the correct Python version is being used for the provided Cassandra package link stated below
+2. It is recommended to run Cassandra under a dedicated `cassandra` user (in the `k2view` group) with its home/installation directory at `/opt/apps/cassandra/`:
 
     ~~~bash
-    python --version
+    mkdir -p /opt/apps
+    groupadd -f k2view
+    useradd -m -d /opt/apps/cassandra -g k2view -s /bin/bash cassandra
+    chown -R cassandra:k2view /opt/apps/cassandra
     ~~~
 
-> **For Cassandra 4.x Configurations**  
-> After setup, please review your `cassandra.yaml` for deprecated options (such as `allocate_tokens_for_keyspace`) and update Java/TLS settings in line with Cassandra 4.x performance and security guidelines.
+3. Install the latest version of Java 11, either the Oracle Java Standard Edition 11 (Long Term Support) or OpenJDK 11 (see the [Apache prerequisites](https://cassandra.apache.org/doc/4.1/cassandra/getting_started/installing.html#prerequisites)). Download from:
 
-### Load the Package on all Nodes
+    - Oracle JDK 11: https://www.oracle.com/java/technologies/javase/jdk11-archive-downloads.html
+    - OpenJDK 11: https://jdk.java.net/archive/ (direct Linux x64 tarball: https://download.java.net/java/ga/jdk11/openjdk-11_linux-x64_bin.tar.gz)
 
-1. Log in to the previously created user that was designated to the Cassandra installation.
-
-2. Download the latest Cassandra package (located [here](https://download.k2view.com/index.php/s/tkf2P1724iBogIj)).
-
-2. Log in to the Linux server as the Cassandra user and copy the package to the home directory.
-
-3. Untar the package (the package name varies according to the version) as follows:
+    To verify that you have the correct version of Java installed, type `java -version`:
 
     ~~~bash
-    tar -zxvf k2v_cassandra-x.xx.xxx.tar.gz -C /opt/apps/cassandra && source /opt/apps/cassandra/.bash_profile
-    ~~~
-> Note: The setup script will use the folder it runs from.
-
-### Set up the Cassandra Nodes
-
-The number of seed nodes should match the chosen replication factor number.
-
-**Required mandatory details:**
-* Seed node IPs
-* Cassandra admin user
-* Cassandra admin password
-
-
-**Optional details:**
-* DataCenter name – unless defined otherwise, the default will be set as DC1
-* Cluster name – unless defined otherwise, the default will be set as Cassandra
-* Replication factor number
-* Hardening and SSl configuration, TBD 
-
-
-#### Multi-Node Setup
-1. Run the following command on the seed nodes only (start with the 1st node, then run it one by one on the 2nd and 3rd):
-
-    ~~~bash
-    /opt/apps/cassandra/cassandra-setup.sh --cassandra_seeds 10.0.0.1,10.0.0.2,10.0.0.3 --cassandra_user k2admin --cassandra_password changeit --cassandra_replication_factor 3
+    java -version
     ~~~
 
-2. Once all seed nodes are up and running, run the same command on the rest of the Cassandra nodes (one by one):
-    > In case you have no additional nodes, run the command on one of the existing seed nodes to finalize configuration.
+    > *Recommended:* Set `JAVA_HOME` and add its `bin` to the `PATH` in the `cassandra` user's `.bash_profile` so Cassandra can always locate the JVM (point the path at your JDK 11 install location):
+    >
+    > ~~~bash
+    > echo "export JAVA_HOME=/opt/apps/cassandra/jdk-11" >> ~/.bash_profile
+    > echo 'export PATH=$JAVA_HOME/bin:$PATH' >> ~/.bash_profile
+    > source ~/.bash_profile
+    > ~~~
+
+4. Verify that a supported Python 3 interpreter is available (required for `cqlsh`):
 
     ~~~bash
-    /opt/apps/cassandra/cassandra-setup.sh --cassandra_seeds 10.0.0.1,10.0.0.2,10.0.0.3 --cassandra_user k2admin --cassandra_password changeit --cassandra_replication_factor 3
+    python3 --version
     ~~~
 
-#### Single-Node Setup
+### Download and Install on all Nodes
 
-1. Run the following command:
+1. Log in to the previously created user that was designated to the Cassandra installation (`cassandra`).
+
+2. Download the latest **Apache Cassandra 4.1.x** binary tarball from the official site (https://cassandra.apache.org/download/). For example:
 
     ~~~bash
-    /opt/apps/cassandra/cassandra-setup.sh --listeners --cassandra_user k2admin --cassandra_password changeit
+    cd /opt/apps/cassandra
+    curl -OL https://dlcdn.apache.org/cassandra/4.1.11/apache-cassandra-4.1.11-bin.tar.gz
     ~~~
 
-### Cassandra cluster - Start, Shutdown, and Status 
-
-* To stop the Cassandra cluster, run the following command on each node (seed nodes should be shut down last):
+3. Extract the package and set `CASSANDRA_HOME`:
 
     ~~~bash
-    /opt/apps/cassandra/cassandra/bin/stop-server
+    tar -zxvf apache-cassandra-4.1.11-bin.tar.gz -C /opt/apps/cassandra
+    export CASSANDRA_HOME=/opt/apps/cassandra/apache-cassandra-4.1.11
     ~~~
 
-* To start the Cassandra cluster, run the following command on each node, one by one, (seed nodes should be started first):
-    ~~~bash
-    /opt/apps/cassandra/cassandra/bin/cassandra
-    ~~~~
+    > *Tip:* Persist `CASSANDRA_HOME` and add it to the `PATH` in the `cassandra` user's `.bash_profile` so the `cassandra`, `nodetool`, and `cqlsh` commands are always available:
+    >
+    > ~~~bash
+    > echo "export CASSANDRA_HOME=/opt/apps/cassandra/apache-cassandra-4.1.11" >> ~/.bash_profile
+    > echo 'export PATH=$CASSANDRA_HOME/bin:$PATH' >> ~/.bash_profile
+    > source ~/.bash_profile
+    > ~~~
 
-* To check all nodes statuses, run the nodetool command:
+> **Note:** The commands above use `4.1.11` as an example. Any **4.1.x** release is supported — substitute the latest 4.1.x patch version in the download URL and paths. Always download from the official Apache mirror and follow the [Apache Cassandra 4.1 documentation](https://cassandra.apache.org/doc/4.1/) for version-specific details.
+
+### Configure the Cassandra Nodes
+
+Apply the following changes under `$CASSANDRA_HOME/conf/` **on every node** before the first start. The values for `listen_address`, `rpc_address`, and `broadcast_rpc_address` are written into the data directory on first boot — Cassandra will refuse to start if they change afterwards, so get them right the first time.
+
+**Required details:**
+* Seed node IPs (the number of seed nodes should match the chosen replication factor)
+* Cassandra admin user and password
+* DataCenter name (default: `DC1`)
+* Cluster name (default: `Cassandra`)
+* Replication factor
+
+The `sed` commands in each step below reference the following variables. Set the config-file paths, then **optionally** override any value — if you leave one unset, the `sed` command falls back to a sensible default (this node's first IP, `DC1`, etc.):
+
+~~~bash
+export CONF=$CASSANDRA_HOME/conf/cassandra.yaml
+export RACKDC=$CASSANDRA_HOME/conf/cassandra-rackdc.properties
+export ENV_SH=$CASSANDRA_HOME/conf/cassandra-env.sh
+
+# Optional overrides — uncomment/edit only what you need:
+# NODE_IP=10.0.0.1                          # defaults to this host's first IP
+# SEEDS="10.0.0.1,10.0.0.2,10.0.0.3"        # defaults to this node's IP (single-node)
+# CLUSTER_NAME=Cassandra
+# DC=DC1
+# RACK=RAC1
+~~~
+
+#### Step 1 — Network (`cassandra.yaml`)
+
+~~~yaml
+# Bind address for inter-node communication (never 0.0.0.0)
+listen_address: <node_private_ip>
+
+# CQL client listen address — 0.0.0.0 accepts from all interfaces
+rpc_address: 0.0.0.0
+
+# Advertised address for clients — must be reachable from the Fabric nodes
+broadcast_rpc_address: <node_private_ip>
+~~~
+
+~~~bash
+sed -i "s/^listen_address:.*/listen_address: ${NODE_IP:-$(hostname -I | awk '{print $1}')}/" "$CONF"
+sed -i "s/^rpc_address:.*/rpc_address: 0.0.0.0/" "$CONF"
+sed -i "s/^# broadcast_rpc_address:.*/broadcast_rpc_address: ${NODE_IP:-$(hostname -I | awk '{print $1}')}/" "$CONF"
+~~~
+
+> Setting `rpc_address` to `0.0.0.0` makes Cassandra listen on all interfaces. When you do this you **must** also set `broadcast_rpc_address` to the node's reachable IP, otherwise Cassandra will refuse to start (it cannot gossip `0.0.0.0` to the rest of the cluster).
+
+#### Step 2 — Cluster Identity (`cassandra.yaml` + `cassandra-rackdc.properties`)
+
+~~~yaml
+# cassandra.yaml
+cluster_name: 'Cassandra'
+
+# At least one seed per DC; for a single node use its own IP
+seeds: "10.0.0.1,10.0.0.2,10.0.0.3"
+~~~
+
+~~~properties
+# cassandra-rackdc.properties
+dc=DC1
+rack=RAC1
+~~~
+
+~~~bash
+sed -i "s/^cluster_name:.*/cluster_name: '${CLUSTER_NAME:-Cassandra}'/" "$CONF"
+sed -i "s/.*- seeds:.*/          - seeds: \"${SEEDS:-$(hostname -I | awk '{print $1}')}\"/" "$CONF"
+sed -i "s/^dc=.*/dc=${DC:-DC1}/" "$RACKDC"
+sed -i "s/^rack=.*/rack=${RACK:-RAC1}/" "$RACKDC"
+~~~
+
+#### Step 3 — Snitch (`cassandra.yaml`)
+
+~~~yaml
+endpoint_snitch: GossipingPropertyFileSnitch
+~~~
+
+~~~bash
+sed -i "s/^endpoint_snitch:.*/endpoint_snitch: GossipingPropertyFileSnitch/" "$CONF"
+~~~
+
+> `GossipingPropertyFileSnitch` reads `dc=` / `rack=` from each node's `cassandra-rackdc.properties` and gossips it to the ring. It is the standard choice for any production cluster — even single-DC — because it enables future DC expansion without a full restart.
+
+#### Step 4 — Authentication (`cassandra.yaml`)
+
+~~~yaml
+authenticator: PasswordAuthenticator
+authorizer: AllowAllAuthorizer      # switch to CassandraAuthorizer for per-keyspace GRANT control
+role_manager: CassandraRoleManager
+~~~
+
+~~~bash
+sed -i "s/^authenticator:.*/authenticator: PasswordAuthenticator/" "$CONF"
+~~~
+
+#### Step 5 — JMX (`cassandra-env.sh`)
+
+By default `LOCAL_JMX=yes` restricts JMX to `127.0.0.1`, which is fine for most setups. If remote JMX access is required (monitoring, `nodetool` from another host):
+
+~~~bash
+# conf/cassandra-env.sh
+LOCAL_JMX=yes    # keep 'yes' unless you need remote JMX (set to 'no' when enabling SSL — see hardening guide)
+
+# Uncomment and set to the node's IP so remote nodetool can reach it
+JVM_OPTS="$JVM_OPTS -Djava.rmi.server.hostname=<node_private_ip>"
+~~~
+
+Only needed for remote JMX — uncomment and set the RMI hostname to this node's IP:
+
+~~~bash
+sed -i "s|^#*JVM_OPTS=\"\$JVM_OPTS -Djava.rmi.server.hostname=.*|JVM_OPTS=\"\$JVM_OPTS -Djava.rmi.server.hostname=${NODE_IP:-$(hostname -I | awk '{print $1}')}\"|" "$ENV_SH"
+~~~
+
+Create the JMX password file (referenced when JMX authentication is enabled):
+
+~~~bash
+echo "k2admin changeit" > $CASSANDRA_HOME/conf/.jmxremote.password
+chmod 400 $CASSANDRA_HOME/conf/.jmxremote.password
+~~~
+
+#### Step 6 — Graceful Stop (`bin/stop-server`)
+
+Vanilla 4.1.x ships `bin/stop-server` as an empty stub. Replace it with a proper graceful drain so nodes shut down cleanly:
+
+~~~bash
+#!/bin/bash
+NODETOOL="$CASSANDRA_HOME/bin/nodetool -u k2admin -pw changeit"
+$NODETOOL status          # check node status
+$NODETOOL disablegossip   # stop accepting new writes from other nodes
+$NODETOOL flush           # flush memtables to disk
+$NODETOOL drain           # flush + stop listening for client requests
+$NODETOOL stopdaemon      # shut down the process
+~~~
+
+### First Boot and Post-Boot Configuration
+
+#### Start Cassandra
+Start Cassandra:
+~~~bash
+$CASSANDRA_HOME/bin/cassandra
+~~~
+
+> **Note (multi-node):** Start the **seed nodes first**, one by one (node 1, then node 2, then node 3). Once all seed nodes report `UN` (Up/Normal) in `nodetool status`, start the remaining nodes one by one. For a single node, just start Cassandra (its `seeds` is set to its own IP).
+
+#### Create the Admin User (run once, after first boot)
+
+Connect with the default credentials and create your own superuser:
+
+~~~bash
+cqlsh -u cassandra -p cassandra <node_ip>
+~~~
+
+~~~sql
+-- Create the admin user
+CREATE ROLE k2admin WITH PASSWORD = 'changeit' AND LOGIN = true AND SUPERUSER = true;
+~~~
+
+> **Important:** Verify that `k2admin` can log in (open a second session) **before** dropping the default `cassandra` role. Once dropped it cannot be recovered without restarting with `AllowAllAuthenticator`.
+
+~~~sql
+-- After confirming the new superuser works:
+DROP ROLE cassandra;
+~~~
+
+#### System Keyspace Replication (multi-node only)
+
+After all nodes are `UN`, update the system keyspaces from the default `SimpleStrategy` to `NetworkTopologyStrategy` (set `<RF>` to your replication factor — RF should equal the number of nodes, up to 3):
+
+~~~sql
+ALTER KEYSPACE system_auth        WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'DC1': <RF>};
+ALTER KEYSPACE system_distributed WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'DC1': <RF>};
+ALTER KEYSPACE system_traces      WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'DC1': <RF>};
+~~~
+
+Then run a repair to distribute the data:
+
+~~~bash
+$CASSANDRA_HOME/bin/nodetool -u k2admin -pw changeit repair -full
+~~~
+
+### Cassandra cluster - Start, Shutdown, and Status
+
+* To **stop** the Cassandra cluster, run the graceful stop on each node (seed nodes should be shut down last):
 
     ~~~bash
-    /opt/apps/cassandra/cassandra/bin/nodetool -u k2admin -pw changeit status
+    $CASSANDRA_HOME/bin/stop-server
     ~~~
+
+* To **start** the Cassandra cluster, run the following command on each node, one by one (seed nodes should be started first):
+
+    ~~~bash
+    $CASSANDRA_HOME/bin/cassandra
+    ~~~
+
+* To check all node statuses, run the `nodetool` command:
+
+    ~~~bash
+    $CASSANDRA_HOME/bin/nodetool -u k2admin -pw changeit status
+    ~~~
+
+## SSL / TLS Hardening (Optional, Recommended for Production)
+
+SSL/TLS configuration — certificate generation, inter-node and client encryption, `cqlshrc`, and JMX over SSL — is covered in the dedicated hardening guide:
+
+[Cassandra Hardening Procedures](/articles/99_fabric_infras/04_cassandra_hardening.md)
+
+## Summary of All Changes from Vanilla Defaults
+
+| File | Setting | Vanilla default | Recommended value |
+|------|---------|----------------|-------------------|
+| `cassandra.yaml` | `listen_address` | `localhost` | node private IP |
+| `cassandra.yaml` | `rpc_address` | `localhost` | `0.0.0.0` |
+| `cassandra.yaml` | `broadcast_rpc_address` | *(commented)* | node private IP |
+| `cassandra.yaml` | `seeds` | `127.0.0.1` | real seed IPs |
+| `cassandra.yaml` | `cluster_name` | `Test Cluster` | custom name |
+| `cassandra.yaml` | `endpoint_snitch` | `SimpleSnitch` | `GossipingPropertyFileSnitch` |
+| `cassandra.yaml` | `authenticator` | `AllowAllAuthenticator` | `PasswordAuthenticator` |
+| `cassandra-rackdc.properties` | `dc=` | `dc1` | `DC1` (or custom) |
+| `cassandra-env.sh` | `LOCAL_JMX` | `yes` | `yes` / `no` (SSL) |
+| `cassandra-env.sh` | `java.rmi.server.hostname` | *(commented)* | node private IP |
+| `conf/.jmxremote.password` | *(not present)* | — | created with superuser credentials |
+| `bin/stop-server` | *(stub)* | — | drain → stopdaemon |
+
+**Post-boot CQL (always):** create the `k2admin` superuser and drop the default `cassandra` role.
+
+**Multi-node:** update `system_auth`, `system_distributed`, and `system_traces` to `NetworkTopologyStrategy`, then run `nodetool repair -full`.
+
+**SSL/TLS:** see the [Cassandra Hardening Procedures](/articles/99_fabric_infras/04_cassandra_hardening.md).

--- a/articles/98_installation_and_upgrade/Install_on_Linux/Cassandra_Setup.md
+++ b/articles/98_installation_and_upgrade/Install_on_Linux/Cassandra_Setup.md
@@ -67,17 +67,20 @@ This guide targets **Apache Cassandra 4.1.x**.
     curl -OL https://dlcdn.apache.org/cassandra/4.1.11/apache-cassandra-4.1.11-bin.tar.gz
     ~~~
 
-3. Extract the package and set `CASSANDRA_HOME`:
+3. Extract the package, create a version-independent `cassandra` symlink, and set `CASSANDRA_HOME` to point at it:
 
     ~~~bash
     tar -zxvf apache-cassandra-4.1.11-bin.tar.gz -C /opt/apps/cassandra
-    export CASSANDRA_HOME=/opt/apps/cassandra/apache-cassandra-4.1.11
+    ln -sfn /opt/apps/cassandra/apache-cassandra-4.1.11 /opt/apps/cassandra/cassandra
+    export CASSANDRA_HOME=/opt/apps/cassandra/cassandra
     ~~~
+
+    > Using the `cassandra` symlink as `CASSANDRA_HOME` keeps all paths version-independent — to upgrade later, extract the new release and repoint the link (`ln -sfn`) without touching any other configuration.
 
     > *Tip:* Persist `CASSANDRA_HOME` and add it to the `PATH` in the `cassandra` user's `.bash_profile` so the `cassandra`, `nodetool`, and `cqlsh` commands are always available:
     >
     > ~~~bash
-    > echo "export CASSANDRA_HOME=/opt/apps/cassandra/apache-cassandra-4.1.11" >> ~/.bash_profile
+    > echo "export CASSANDRA_HOME=/opt/apps/cassandra/cassandra" >> ~/.bash_profile
     > echo 'export PATH=$CASSANDRA_HOME/bin:$PATH' >> ~/.bash_profile
     > source ~/.bash_profile
     > ~~~

--- a/articles/99_fabric_infras/04_cassandra_hardening.md
+++ b/articles/99_fabric_infras/04_cassandra_hardening.md
@@ -9,81 +9,69 @@
 - [Step 5 - Disable the default cassandra superuser](#step-5---disable-the-default-cassandra-superuser)
 
 
-The following steps ensure that the keys that secure Fabric and Cassandra are correctly generated and configured.
+The following steps ensure that the keys that secure Fabric and Cassandra are correctly generated and configured on a **vanilla Apache Cassandra 4.1.x** installation (see the [Cassandra Setup guide](/articles/98_installation_and_upgrade/Install_on_Linux/Cassandra_Setup.md)).
 
-- The example password ```Q1w2e3r4t5``` is used for TLS keys and can be replaced in all of the following sections by a new password.
-- Do not forget to replace all `$K2_HOME/` & `$INSTALL_DIR`  values with the complete and correct path location for both Fabric and Cassandra.
+- The example password ```changeit``` is used for the TLS keys, and the cluster name defaults to ```Cassandra```. Both can be replaced in all of the following sections (export `CLUSTER_NAME` before running the commands to use a different name).
+- These steps assume `$CASSANDRA_HOME` is set to the `cassandra` symlink (`/opt/apps/cassandra/cassandra`) created in the Cassandra Setup guide. All keys are generated under `/opt/apps/cassandra/.cassandra_ssl`; the keystore and truststore are then deployed to `$CASSANDRA_HOME/conf/.keystore` and `$CASSANDRA_HOME/conf/.truststore` (the paths the stock `cassandra.yaml` already references).
+- `keytool` (bundled with the JDK) and `openssl` must be available on the `PATH`.
 
 
 ## Step 1 - Keys Generation
 
-1. Connect as **cassandra** user.
-2. Run the `secure_cassandra.sh` file that generates the keys. This file is included within our supplied package or can be downloaded from [here](https://owncloud-bkp2.s3.amazonaws.com/adminoc/Utils/Hardening/secure_cassandra.sh). 
-3. Stop Cassandra services before running the script.
-    ```bash
-    ## run: 
-    stop-server
-    ```
+Run the following **on a single Cassandra node only**, connected as the **cassandra** user. The commands generate a cluster keypair (for inter-node encryption) and a client keypair (for client-to-node encryption), build the keystore and truststore, and extract the client key/certificate in PEM format for `cqlsh` and Fabric.
 
-    ```bash
-    echo "export K2_HOME=$INSTALL_DIR" >> .bash_profile
-    source ~/.bash_profile
-    cd ~/
-    rm -rf .cassandra .cassandra_ssl .oracle_jre_usage .ssl
-    ````
+> To use a different password or cluster name, change `changeit` and export `CLUSTER_NAME` (e.g. `export CLUSTER_NAME=Cassandra`) before running the commands.
 
-    **Note:** Run the below command on a single Cassandra node only. To change the password or cluster name, edit the secure_cassandra.sh file or execute it using the password and cluster name parameters.
+~~~bash
+export SSL_DIR=/opt/apps/cassandra/.cassandra_ssl
+export CLUSTER_NAME=${CLUSTER_NAME:-Cassandra}
+export KEYSTORE_PASSWORD=changeit
+mkdir -p $SSL_DIR && cd $SSL_DIR
 
+# 1. Generate the cluster (node) keypair
+keytool -genkeypair -keyalg RSA -keysize 2048 -alias ${CLUSTER_NAME}_cluster \
+  -keystore cassandra.keystore -storepass ${KEYSTORE_PASSWORD} -keypass ${KEYSTORE_PASSWORD} \
+  -validity 3650 -dname "CN=${CLUSTER_NAME}, OU=Cassandra, O=K2view, C=US"
 
-    ```bash
-    ./secure_cassandra.sh {Password} {Cluster_Name}
-    ```
+# 2. Generate the client keypair (used by cqlsh / Fabric)
+keytool -genkeypair -keyalg RSA -keysize 2048 -alias ${CLUSTER_NAME}_client \
+  -keystore cassandra.keystore -storepass ${KEYSTORE_PASSWORD} -keypass ${KEYSTORE_PASSWORD} \
+  -validity 3650 -dname "CN=${CLUSTER_NAME}_client, OU=Cassandra, O=K2view, C=US"
 
-    For example: 
+# 3. Export the public certificates
+keytool -exportcert -alias ${CLUSTER_NAME}_cluster -keystore cassandra.keystore \
+  -storepass ${KEYSTORE_PASSWORD} -file CLUSTER_${CLUSTER_NAME}_PUBLIC.cer
+keytool -exportcert -alias ${CLUSTER_NAME}_client -keystore cassandra.keystore \
+  -storepass ${KEYSTORE_PASSWORD} -file CLIENT_${CLUSTER_NAME}_PUBLIC.cer
 
-    ```bash
-    ./secure_cassandra.sh Q1w2e3r4t5 k2tls
-    ```
-    An output example:
-    
-    ```bash
-    Warning:
-    The JKS Keystore uses a proprietary format. It is recommended to migrate    to PKCS12, which is an industry standard format using "keytool  -importkeystore -srckeystore /opt/apps/k2view/.cassandra_ssl/cassandra.  keystore -destkeystore /opt/apps/k2view/.cassandra_ssl/cassandra. keystore -deststoretype pkcs12".
-    Certificate stored in file </opt/apps/k2view/.cassandra_ssl/    CLUSTER_k2tls_PUBLIC.cer>
-    
-    Warning:
-    The JKS Keystore uses a proprietary format. It is recommended to migrate    to PKCS12, which is an industry standard format using "keytool  -importkeystore -srckeystore /opt/apps/k2view/.cassandra_ssl/cassandra.  keystore -destkeystore /opt/apps/k2view/.cassandra_ssl/cassandra. keystore -deststoretype pkcs12".
-    Certificate was added to the keystore
-    [Storing /opt/apps/k2view/.cassandra_ssl/cassandra.truststore]
-    
-    Warning:
-    The JKS Keystore uses a proprietary format. It is recommended to migrate    to PKCS12, which is an industry standard format using "keytool  -importkeystore -srckeystore /opt/apps/k2view/.cassandra_ssl/cassandra.  keystore -destkeystore /opt/apps/k2view/.cassandra_ssl/cassandra. keystore -deststoretype pkcs12".
-    Certificate stored in file </opt/apps/k2view/.cassandra_ssl/    CLIENT_k2tls_PUBLIC.cer>
-    
-    Warning:
-    The JKS Keystore uses a proprietary format. It is recommended to migrate    to PKCS12, which is an industry standard format using "keytool  -importkeystore -srckeystore /opt/apps/k2view/.cassandra_ssl/cassandra.  keystore -destkeystore /opt/apps/k2view/.cassandra_ssl/cassandra. keystore -deststoretype pkcs12".
-    Certificate was added to the keystore
-    [Storing /opt/apps/k2view/.cassandra_ssl/cassandra.truststore]
-    Importing keystore /opt/apps/k2view/.cassandra_ssl/cassandra.keystore to    /opt/apps/k2view/.cassandra_ssl/cassandra.pks12.keystore...
-    Entry for alias k2tls_client successfully imported.
-    Entry for alias k2tls_cluster successfully imported.
-    Import command completed:  2 entries successfully imported, 0 entries   failed or cancelled
-    MAC verified OK
-    MAC verified OK 
-    ```
-    
-    The following 7 files will be created under the `$INSTALL_DIR/.cassandra_ssl` directory:
-    - k2tls_CLIENT.key.pem
-    - k2tls_CLIENT.cer.pem
-    - cassandra.keystore
-    - cassandra.pks12.keystore
-    - cassandra.truststore
-    - CLIENT_k2tls_PUBLIC.cer
-    - CLUSTER_k2tls_PUBLIC.cer
+# 4. Build the truststore from the public certificates
+keytool -importcert -noprompt -alias ${CLUSTER_NAME}_cluster -file CLUSTER_${CLUSTER_NAME}_PUBLIC.cer \
+  -keystore cassandra.truststore -storepass ${KEYSTORE_PASSWORD}
+keytool -importcert -noprompt -alias ${CLUSTER_NAME}_client -file CLIENT_${CLUSTER_NAME}_PUBLIC.cer \
+  -keystore cassandra.truststore -storepass ${KEYSTORE_PASSWORD}
 
-    A cassandra_keys.tar.gz file, containing all of the above files, will be created, so it can be transferred to the other nodes.
+# 5. Extract the client key and certificate in PEM format (for cqlsh / Fabric)
+keytool -importkeystore -srckeystore cassandra.keystore -srcstorepass ${KEYSTORE_PASSWORD} \
+  -srcalias ${CLUSTER_NAME}_client -destkeystore cassandra.pks12.keystore \
+  -deststoretype PKCS12 -deststorepass ${KEYSTORE_PASSWORD}
+openssl pkcs12 -legacy -in cassandra.pks12.keystore -passin pass:${KEYSTORE_PASSWORD} -nocerts -nodes -out ${CLUSTER_NAME}_CLIENT.key.pem
+openssl pkcs12 -legacy -in cassandra.pks12.keystore -passin pass:${KEYSTORE_PASSWORD} -clcerts -nokeys -out ${CLUSTER_NAME}_CLIENT.cer.pem
 
-    > Note that the key and certificate file names contain the cluster name you have set.
+# 6. Bundle the keys for transfer to the other nodes
+tar -zcvf cassandra_keys.tar.gz cassandra.keystore cassandra.truststore cassandra.pks12.keystore \
+  ${CLUSTER_NAME}_CLIENT.key.pem ${CLUSTER_NAME}_CLIENT.cer.pem CLIENT_${CLUSTER_NAME}_PUBLIC.cer CLUSTER_${CLUSTER_NAME}_PUBLIC.cer
+~~~
+
+The following 7 files are created under `/opt/apps/cassandra/.cassandra_ssl` (file names contain your cluster name — `Cassandra` by default):
+- &lt;CLUSTER_NAME&gt;_CLIENT.key.pem
+- &lt;CLUSTER_NAME&gt;_CLIENT.cer.pem
+- cassandra.keystore
+- cassandra.pks12.keystore
+- cassandra.truststore
+- CLIENT_&lt;CLUSTER_NAME&gt;_PUBLIC.cer
+- CLUSTER_&lt;CLUSTER_NAME&gt;_PUBLIC.cer
+
+The `cassandra_keys.tar.gz` archive bundles all of the above so it can be transferred to the other nodes.
 
 ## Step 2 - Transfer Keys and Certificates to All Cassandra and Fabric Nodes
 
@@ -92,13 +80,17 @@ Copy the previously created file  *cassandra_keys.tar.gz* to all Cassandra nodes
 See the example below: 
 
 ``` bash
+# copy the archive to the other nodes in case more than one node is used
+# 10.10.10.10 represents the IP address of another node
+scp /opt/apps/cassandra/.cassandra_ssl/cassandra_keys.tar.gz cassandra@10.10.10.10:/opt/apps/cassandra/.cassandra_ssl/
 
-# copy to other nodes in case more than one node is used
-# 10.10.10.10 represents IP address of another node
-scp  cassandra_keys.tar.gz cassandra@10.10.10.10:/opt/apps/cassandra/
+# on each OTHER node, unpack the archive into the same directory
+mkdir -p /opt/apps/cassandra/.cassandra_ssl && tar -zxvf cassandra_keys.tar.gz -C /opt/apps/cassandra/.cassandra_ssl
 
-# login to every node separately and run the following command
-mkdir -p $INSTALL_DIR/.cassandra_ssl && tar -zxvf cassandra_keys.tar.gz -C $INSTALL_DIR/.cassandra_ssl
+# on ALL nodes (including the one that generated the keys), deploy the
+# keystore and truststore to the Cassandra conf directory
+cp /opt/apps/cassandra/.cassandra_ssl/cassandra.keystore   $CASSANDRA_HOME/conf/.keystore
+cp /opt/apps/cassandra/.cassandra_ssl/cassandra.truststore $CASSANDRA_HOME/conf/.truststore
 ```
 
 ## Step 3 - Cassandra YAML
@@ -109,20 +101,19 @@ mkdir -p $INSTALL_DIR/.cassandra_ssl && tar -zxvf cassandra_keys.tar.gz -C $INST
 
 ```bash
 sed -i "s@internode_encryption: none@internode_encryption: all@" $CASSANDRA_HOME/conf/cassandra.yaml
-sed -i "s@key_password: cassandra@key_password: Q1w2e3r4t5@" $CASSANDRA_HOME/conf/cassandra.yaml
-sed -i "s@keystore: conf/.keystore*@keystore: $INSTALL_DIR/.cassandra_ssl/cassandra.keystore@" $CASSANDRA_HOME/conf/cassandra.yaml
+sed -i "s@key_password: cassandra@key_password: changeit@" $CASSANDRA_HOME/conf/cassandra.yaml
+sed -i "s@keystore: conf/.keystore*@keystore: $CASSANDRA_HOME/conf/.keystore@" $CASSANDRA_HOME/conf/cassandra.yaml
 sed -i "s@# truststore:@truststore:@" $CASSANDRA_HOME/conf/cassandra.yaml
-sed -i "s@truststore: conf/.truststore*@truststore: $INSTALL_DIR/.cassandra_ssl/cassandra.truststore@" $CASSANDRA_HOME/conf/cassandra.yaml
+sed -i "s@truststore: conf/.truststore*@truststore: $CASSANDRA_HOME/conf/.truststore@" $CASSANDRA_HOME/conf/cassandra.yaml
 sed -i "s@# protocol: TLS*@protocol: TLS@" $CASSANDRA_HOME/conf/cassandra.yaml
-sed -i "s@keystore_password: cassandra@keystore_password: Q1w2e3r4t5@" $CASSANDRA_HOME/conf/cassandra.yaml
-sed -i "s@# truststore: conf/.truststore*@truststore: $INSTALL_DIR/.cassandra_ssl/cassandra.truststore@" $CASSANDRA_HOME/conf/cassandra.yaml
-sed -i "s@# truststore_password: cassandra*@truststore_password: Q1w2e3r4t5@" $CASSANDRA_HOME/conf/cassandra.yaml
-sed -i "s@truststore_password: cassandra*@truststore_password: Q1w2e3r4t5@" $CASSANDRA_HOME/conf/cassandra.yaml
+sed -i "s@keystore_password: cassandra@keystore_password: changeit@" $CASSANDRA_HOME/conf/cassandra.yaml
+sed -i "s@# truststore: conf/.truststore*@truststore: $CASSANDRA_HOME/conf/.truststore@" $CASSANDRA_HOME/conf/cassandra.yaml
+sed -i "s@# truststore_password: cassandra*@truststore_password: changeit@" $CASSANDRA_HOME/conf/cassandra.yaml
+sed -i "s@truststore_password: cassandra*@truststore_password: changeit@" $CASSANDRA_HOME/conf/cassandra.yaml
 sed -i "s@# protocol: TLS*@protocol: TLS@" $CASSANDRA_HOME/conf/cassandra.yaml
 sed -i "s@# require_client_auth: .*@require_client_auth: false@g" $CASSANDRA_HOME/conf/cassandra.yaml
 sed -i "s@# store_type: JKS@store_type: JKS@g" $CASSANDRA_HOME/conf/cassandra.yaml
 sed -i '0,/enabled: false/! {0,/enabled: false/ s/enabled: false/enabled: true/}' $CASSANDRA_HOME/conf/cassandra.yaml
-sed -i -e 's/# \(.*cipher_suites.*\)/\1/g' $CASSANDRA_HOME/conf/cassandra.yaml
 sed -i -e 's/# \(.*native_transport_port_ssl:.*\)/\1/g' $CASSANDRA_HOME/conf/cassandra.yaml
 sed -i '1,/cdc_enabled: false/ {0,/cdc_enabled: false/ s/cdc_enabled: false/cdc_enabled: true/}' $CASSANDRA_HOME/conf/cassandra.yaml
 sed -i "s@back_pressure_enabled: .*@back_pressure_enabled: true@" $CASSANDRA_HOME/conf/cassandra.yaml
@@ -138,24 +129,31 @@ sed -i -e 's/# \(.*native_transport_port_ssl:.*\)/\1/g' $CASSANDRA_HOME/conf/cas
 2. Execute this as a Cassandra user on all Cassandra nodes. 
 > Replace the key and certificate file names with the files created earlier.
 
-    ```bash
-    mkdir -p ~/.cassandra
-    cp $INSTALL_DIR/cassandra/conf/cqlshrc.sample $INSTALL_DIR/.cassandra/cqlshrc
-
-    sed -i "s@\;\[ssl\]@\[ssl\]@" $INSTALL_DIR/.cassandra/cqlshrc
-    sed -i '/^\[csv]/i factory = cqlshlib.ssl.ssl_transport_factory' $INSTALL_DIR/.cassandra/cqlshrc
-    sed -i "s@; certfile = .*@certfile = $INSTALL_DIR/.cassandra_ssl/k2tls_CLIENT.cer.pem@" $INSTALL_DIR/.cassandra/cqlshrc
-    sed -i "s@;validate = true@validate = true@" $INSTALL_DIR/.cassandra/cqlshrc
-    sed -i "105iversion = SSLv23" $INSTALL_DIR/.cassandra/cqlshrc
-    sed -i "s@;userkey = .*@userkey = $INSTALL_DIR/.cassandra_ssl/k2tls_CLIENT.key.pem@" $INSTALL_DIR/.cassandra/cqlshrc
-    sed -i "s@;usercert = .*@usercert = $INSTALL_DIR/.cassandra_ssl/k2tls_CLIENT.cer.pem@" $INSTALL_DIR/.cassandra/cqlshrc
-    sed -i "s@port = .*@port = 9142@" $INSTALL_DIR/.cassandra/cqlshrc
-    sed -i "s@hostname = .*@hostname = $(hostname -I |awk {'print $1'})@" $INSTALL_DIR/.cassandra/cqlshrc
-    ```
-3. You can check your configuration by connecting to Cassandra with the following command: (use the user and password you have defined earlier)
    ```bash
-   cqlsh -u k2admin -p Q1w2e3r4t5 --ssl
+   export SSL_DIR=/opt/apps/cassandra/.cassandra_ssl
+   export CLUSTER_NAME=${CLUSTER_NAME:-Cassandra}
+   mkdir -p ~/.cassandra
+   cp $CASSANDRA_HOME/conf/cqlshrc.sample ~/.cassandra/cqlshrc
+
+   # cqlsh verifies the node's (server) certificate against 'certfile'. The node presents the
+   # CLUSTER certificate, so convert it from DER (keytool output) to PEM for cqlsh to trust it.
+   openssl x509 -inform der -in $SSL_DIR/CLUSTER_${CLUSTER_NAME}_PUBLIC.cer -out $SSL_DIR/${CLUSTER_NAME}_CLUSTER.cer.pem
+
+   sed -i "s@\;\[ssl\]@\[ssl\]@" ~/.cassandra/cqlshrc
+   sed -i '/^\[csv]/i factory = cqlshlib.ssl.ssl_transport_factory' ~/.cassandra/cqlshrc
+   sed -i "s@; certfile = .*@certfile = $SSL_DIR/${CLUSTER_NAME}_CLUSTER.cer.pem@" ~/.cassandra/cqlshrc
+   sed -i "s@;validate = true@validate = true@" ~/.cassandra/cqlshrc
+   sed -i "105iversion = SSLv23" ~/.cassandra/cqlshrc
+   sed -i "s@;userkey = .*@userkey = $SSL_DIR/${CLUSTER_NAME}_CLIENT.key.pem@" ~/.cassandra/cqlshrc
+   sed -i "s@;usercert = .*@usercert = $SSL_DIR/${CLUSTER_NAME}_CLIENT.cer.pem@" ~/.cassandra/cqlshrc
+   sed -i "s@port = .*@port = 9142@" ~/.cassandra/cqlshrc
+   sed -i "s@hostname = .*@hostname = $(hostname -I |awk {'print $1'})@" ~/.cassandra/cqlshrc
    ```
+3. Check your TLS configuration by connecting to Cassandra. At this point the only account is the bootstrap superuser `cassandra` (the `k2admin` user is created in Step 5), so connect with:
+   ```bash
+   cqlsh -u cassandra -p cassandra --ssl
+   ```
+   After completing Step 5, connect with the new superuser instead: `cqlsh -u k2admin -p changeit --ssl`
 
 ## Step 5 - Disable the default `cassandra` superuser
 
@@ -164,7 +162,7 @@ Cassandra's default superuser is `cassandra`, and it must be disabled before dep
 1. Connect to one of the Cassandra nodes' consoles, and create two new **superusers**
 
    ~~~bash
-   echo "create user k2admin with password 'Q1w2e3r4t5' superuser;" | cqlsh -u cassandra -p cassandra $(hostname -i) 9142 --ssl
+   echo "create user k2admin with password 'changeit' superuser;" | cqlsh -u cassandra -p cassandra $(hostname -i) 9142 --ssl
    echo "create user k2sysdba with password '3ptBF9eMSsyLrXr3' superuser;" | cqlsh -u cassandra -p cassandra $(hostname -i) 9142 --ssl
    ~~~
 

--- a/articles/99_fabric_infras/05_connect_fabric_to_cassandra_with_tls.md
+++ b/articles/99_fabric_infras/05_connect_fabric_to_cassandra_with_tls.md
@@ -1,57 +1,91 @@
 # Connect Fabric to Cassandra in TLS mode
 
-The following steps should be taken in order to connect Fabric to Cassandra in TLS mode.
+The following steps connect Fabric to a TLS-hardened Cassandra cluster (see [Cassandra Hardening](/articles/99_fabric_infras/04_cassandra_hardening.md)).
 
-## Step 1 - Transfer the Cassandra Keys and Certificates to All Fabric Nodes
+Rather than pointing Fabric's JVM at the Cassandra keystore, the Cassandra **client key/certificate** is imported into Fabric's existing keystore, and the Cassandra **server (cluster) public certificate** is imported into Fabric's truststore.
 
-Tar and copy the Cassandra keys and certificates into all the Fabric nodes in the cluster.  
+**Assumptions:**
+- Cassandra was hardened per the [Cassandra Hardening](/articles/99_fabric_infras/04_cassandra_hardening.md) guide. Its keys are under `/opt/apps/cassandra/.cassandra_ssl`, with the default cluster name `Cassandra` and password `changeit` (adjust the file names / password below if you changed them).
+- `${FABRIC_HOME}` is set on each Fabric node.
+- The example password `changeit` is used for the Fabric keystore and truststore — replace it if your stores use a different one.
 
-1. Prepare a tar file with all the certificates on one of the Cassandra nodes, as shown in the below example
+## Step 1 - Copy the Cassandra keys archive to all Fabric nodes
 
-   ~~~bash
-   tar -czvf keys.tar.gz -C $INSTALL_DIR/.cassandra_ssl .
-   ~~~
+From one of the Cassandra nodes, copy the `cassandra_keys.tar.gz` archive (created during hardening) to every Fabric node.
 
-2. Copy the Cassandra keys and certificates to the Fabric nodes
+~~~bash
+# 10.1.0.1 represents the IP address of each Fabric node
+scp /opt/apps/cassandra/.cassandra_ssl/cassandra_keys.tar.gz fabric@10.1.0.1:/opt/apps/fabric/
+~~~
 
-   ~~~bash
-   # copy to all Fabric nodes
-   # 172.27.0.102 represents IP address of each node
-   scp keys.tar.gz fabric@172.27.0.102:/opt/apps/fabric/
-   ~~~
+In case of a Docker installation, copy between the running containers instead:
 
-   In case of a Docker installation, use the following commands to copy between running containers
-   ~~~bash
-   docker cp cassandra:/opt/apps/cassandra/keys.tar.gz ./
-   docker cp keys.tar.gz fabric:/usr/local/k2view/
-   ~~~
+~~~bash
+docker cp cassandra:/opt/apps/cassandra/.cassandra_ssl/cassandra_keys.tar.gz ./
+docker cp cassandra_keys.tar.gz fabric:/opt/apps/fabric/
+~~~
 
-## Step 2 - Set Fabric to connect to Cassandra
+## Step 2 - Import the key and certificate into the Fabric keystore and truststore
 
-1. Stop Fabric `k2fabric stop`.
+Run the following as the **fabric** user **on each Fabric node**. The archive is unpacked first, then the client key/certificate and the cluster public certificate are imported using Fabric's `certificates.sh` helper script (which wraps `keytool`).
 
-2. Extract the `keys.tar.gz` file
+The `FABRIC_KEYSTORE_PATH` / `FABRIC_TRUSTSTORE_PATH` environment variables tell `certificates.sh` which stores to write to. They are set here to the default Fabric stores so that Step 4 applies unchanged.
 
-   ~~~bash
-   mkdir -p $K2_HOME/.cassandra_ssl && tar -zxvf keys.tar.gz -C $K2_HOME/.cassandra_ssl
-   ~~~
+~~~bash
+export FABRIC_KEYSTORE_PATH=${FABRIC_HOME}/config/.keystore
+export FABRIC_TRUSTSTORE_PATH=${FABRIC_HOME}/config/.truststore
 
-3. Edit the `$K2_HOME/config/jvm.options` file using the appropriate passwords and certification files:
+# Unpack the archive
+mkdir -p /opt/apps/fabric/.cassandra_ssl
+tar -zxvf /opt/apps/fabric/cassandra_keys.tar.gz -C /opt/apps/fabric/.cassandra_ssl
+cd /opt/apps/fabric/.cassandra_ssl
 
-    ```bash
-    sed -i "s@#SSL=false@SSL=true@" $K2_HOME/config/config.ini
-    sed -i "s@#PORT=$.*@PORT=9142@" $K2_HOME/config/config.ini
-    sed -i "s@^USER=.*@USER=k2admin@" $K2_HOME/config/config.ini
-    sed -i "s@^PASSWORD=.*@PASSWORD=Q1w2e3r4t5@" $K2_HOME/config/config.ini
-    sed -i 's@#-Djavax.net.ssl.keyStore=.*@-Djavax.net.ssl.keyStore=$K2_HOME/.cassandra_ssl/cassandra.keystore@g' $K2_HOME/config/jvm.options
-    sed -i 's@#-Djavax.net.ssl.keyStorePassword=.*@-Djavax.net.ssl.keyStorePassword=Q1w2e3r4t5@g' $K2_HOME/config/jvm.options
-    sed -i 's@#-Djavax.net.ssl.trustStore=.*@-Djavax.net.ssl.trustStore=$K2_HOME/.cassandra_ssl/cassandra.truststore@g' $K2_HOME/config/jvm.options
-    sed -i 's@#-Djavax.net.ssl.trustStorePassword=.*@-Djavax.net.ssl.trustStorePassword=Q1w2e3r4t5@g' $K2_HOME/config/jvm.options
-    ```
+# 1. Package the Cassandra client key + certificate as PKCS12
+#    (certificates.sh addkey imports a private key, which keytool can only read from a PKCS12 bundle)
+openssl pkcs12 -export -name cassandra_client \
+  -in Cassandra_CLIENT.cer.pem -inkey Cassandra_CLIENT.key.pem \
+  -out cassandra_client.p12 -passout pass:changeit
 
-4. Start the Fabric service on each node: `k2fabric start`.
+# 2. Import the client key/certificate into the Fabric keystore
+${FABRIC_HOME}/fabric/scripts/certificates.sh addkey cassandra_client cassandra_client.p12 changeit
 
+# 3. Import the Cassandra server (cluster) public certificate into the Fabric truststore
+${FABRIC_HOME}/fabric/scripts/certificates.sh addtrust cassandra_cluster CLUSTER_Cassandra_PUBLIC.cer changeit
+~~~
 
+## Step 3 - Enable the TLS connection in config.ini
 
+Update the `default_session` (Cassandra SystemDB) section of `${FABRIC_HOME}/config/config.ini` to enable SSL, set the SSL port, and the credentials of the superuser created during hardening. Fabric's `merge-config.sh` helper sets each key in the named section (creating it if missing), which is safer than a global `sed` because the same key names can appear in other sections.
+
+~~~bash
+${FABRIC_HOME}/fabric/scripts/merge-config.sh -i ${FABRIC_HOME}/config/config.ini -s default_session -k SSL -v true
+${FABRIC_HOME}/fabric/scripts/merge-config.sh -i ${FABRIC_HOME}/config/config.ini -s default_session -k PORT -v 9142
+${FABRIC_HOME}/fabric/scripts/merge-config.sh -i ${FABRIC_HOME}/config/config.ini -s default_session -k USER -v k2admin
+${FABRIC_HOME}/fabric/scripts/merge-config.sh -i ${FABRIC_HOME}/config/config.ini -s default_session -k PASSWORD -v changeit
+~~~
+
+## Step 4 - (Optional) Set the keystore/truststore paths in jvm.options
+
+By default Fabric uses `${FABRIC_HOME}/config/.keystore` and `${FABRIC_HOME}/config/.truststore` (the stores written to in Step 2), so **no change is required** when the defaults are in use.
+
+Run the following **only if** these options are not already set in `${FABRIC_HOME}/config/jvm.options`, to point them explicitly at the default stores:
+
+~~~bash
+sed -i "s@#-Djavax.net.ssl.keyStore=.*@-Djavax.net.ssl.keyStore=${FABRIC_HOME}/config/.keystore@g" ${FABRIC_HOME}/config/jvm.options
+sed -i "s@#-Djavax.net.ssl.keyStorePassword=.*@-Djavax.net.ssl.keyStorePassword=changeit@g" ${FABRIC_HOME}/config/jvm.options
+sed -i "s@#-Djavax.net.ssl.trustStore=.*@-Djavax.net.ssl.trustStore=${FABRIC_HOME}/config/.truststore@g" ${FABRIC_HOME}/config/jvm.options
+sed -i "s@#-Djavax.net.ssl.trustStorePassword=.*@-Djavax.net.ssl.trustStorePassword=changeit@g" ${FABRIC_HOME}/config/jvm.options
+~~~
+
+If the `keyStore` / `trustStore` options have instead been customized to a different path, import the key and certificate into those configured stores (re-run Step 2 with `FABRIC_KEYSTORE_PATH` / `FABRIC_TRUSTSTORE_PATH` pointing at those paths).
+
+## Step 5 - Restart Fabric
+
+Restart the Fabric service on each node:
+
+~~~bash
+k2fabric stop
+k2fabric start
+~~~
 
 [![Previous](/articles/images/Previous.png)](/articles/99_fabric_infras/04_cassandra_hardening.md)[<img align="right" width="60" height="54" src="/articles/images/Next.png">](/articles/99_fabric_infras/06_kafka_hardening.md)


### PR DESCRIPTION
Move from k2v_cassandra to vanilla Apache Cassandra

## General changes
* Remove passwords like "Q1w2..."
* Use generic names and examples
* Remove legacy env vars like K2_HOME, INSTALL_DIR

## Cassandra Setup
* Remove k2v_cassandra-x.xx.xxx.tar.gz
* Refer to official documents and downloads of https://cassandra.apache.org/doc/4.1/
* Generic install and config guides

## Cassandra Hardening
* From Fabric remove the cassandra.keystore and cassandra.truststore, import the key and cert to existing keystore and truststore
* Remove section of warnings like "Warning: The JKS Keystore uses a proprietary format...."
* Remove costume scripts like secure_cassandra.sh and cassandra-setup.sh
